### PR TITLE
repositoryエントリがなかったため追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "engshaper",
   "displayName": "engshaper",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/spdbear/engshaper"
+  },
   "version": "0.0.1",
   "publisher": "spdbear",
   "engines": {


### PR DESCRIPTION
`package.json`に`repository`エントリがないと`$ vsce package`でコケるため修正しました。